### PR TITLE
build: No verbose builds/tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test


### PR DESCRIPTION
Changes build steps to remove `--verbose` from `cargo build` and `cargo test` so as not to clog up build logs